### PR TITLE
create master branch in bare repo

### DIFF
--- a/git_util.py
+++ b/git_util.py
@@ -85,7 +85,7 @@ def init(nickname, master_path, working_path, defs):
 
     stdout, stderr, rc = shell_util.run("git add journal.tex")
     stdout, stderr, rc = shell_util.run("git commit -m 'initial journal.tex file' journal.tex")
-    stdout, stderr, rc = shell_util.run("git push")
+    stdout, stderr, rc = shell_util.run("git push origin master")
 
 
 def connect(master_repo, working_path, defs):

--- a/git_util.py
+++ b/git_util.py
@@ -108,22 +108,11 @@ def connect(master_repo, working_path, defs):
     except:
         sys.exit("ERROR: unable to switch to directory {}".format(working_path))
 
-    ####
-    # This section gives the following error upon 'git pull' or 'pyjournal.py pull'
-    # With git version 2.4.3:
-    # # "Your configuration specifies to merge with the ref 'master'
-    # #  from the remote, but no such ref was fetched."
-
-    # {fix: remove the '.git' at the end of the 'git clone' statement.
-    master_repo_trim = master_repo.replace('.git','')
-    # :fix}
-    
-    stdout, stderr, rc = shell_util.run("git clone " + master_repo_trim)
+    stdout, stderr, rc = shell_util.run("git clone " + master_repo)
     if not rc == 0:
         print stderr
         sys.exit("ERROR: something went wrong with the git clone")
-    ####
-    
+
     # create (or add to) the .pyjournalrc file
     try: f = open(defs["param_file"], "a+")
     except:

--- a/git_util.py
+++ b/git_util.py
@@ -108,11 +108,22 @@ def connect(master_repo, working_path, defs):
     except:
         sys.exit("ERROR: unable to switch to directory {}".format(working_path))
 
-    stdout, stderr, rc = shell_util.run("git clone " + master_repo)
+    ####
+    # This section gives the following error upon 'git pull' or 'pyjournal.py pull'
+    # With git version 2.4.3:
+    # # "Your configuration specifies to merge with the ref 'master'
+    # #  from the remote, but no such ref was fetched."
+
+    # {fix: remove the '.git' at the end of the 'git clone' statement.
+    master_repo_trim = master_repo.replace('.git','')
+    # :fix}
+    
+    stdout, stderr, rc = shell_util.run("git clone " + master_repo_trim)
     if not rc == 0:
         print stderr
         sys.exit("ERROR: something went wrong with the git clone")
-
+    ####
+    
     # create (or add to) the .pyjournalrc file
     try: f = open(defs["param_file"], "a+")
     except:


### PR DESCRIPTION
The push line in 'init' needs to be 'git push origin master' otherwise the master branch isn't created in the bare repository.

Without a master branch, cloning the repo using 'pyjournal.py connect' gives a repo where 'pyjournal.py pull' returns 'Already up-to-date.' but the cloned directory remains empty. 'git pull' in the empty cloned directory returns "Your configuration specifies to merge with the ref 'master' from the remote, but no such ref was fetched."

Looking at stderr from the 'git push' line in 'init', that returns the error:
    No refs in common and none specified; doing nothing.
    Perhaps you should specify a branch such as 'master'.
    fatal: The remote end hung up unexpectedly
    error: failed to push some refs to '/home/dwillcox/journals/journal-test3.git'

This error occured with both git versions 1.7.1 and 2.4.3.

This is fixed by using 'git push origin master' instead of 'git push' in 'init' to create a master branch.
